### PR TITLE
week7/update-scope-lock

### DIFF
--- a/docs/mvp/scope-lock.md
+++ b/docs/mvp/scope-lock.md
@@ -6,6 +6,16 @@ If a feature is not described here, it does not consume sprint time.
 
 ---
 
+## Board Evidence
+
+GitHub Project Board:  
+https://github.com/orgs/Georgia-Southwestern-State-Univeristy/projects/26/views/1
+
+All story statuses below reflect the current state of the repository and project board.  
+“Done” means merged into `main` with CI checks passing.
+
+---
+
 ## MVP User Stories (Locked)
 
 1. **Trip Creation**
@@ -25,6 +35,24 @@ If a feature is not described here, it does not consume sprint time.
 
 6. **Trip Retrieval**
    - As a traveler, I want to retrieve previously saved trips from the server, so I can continue working on them.
+
+---
+
+## MVP Story Status
+
+| MVP Story | Status | Evidence / Notes |
+|----------|--------|------------------|
+| Trip Creation | Done | FE captures trip inputs; backend `POST /api/saveTrip` validates required fields and returns `201` with `id`; merged to `main` with CI green |
+| Checklist Generation | Done | Rule-based generator implemented and covered by unit tests (`tests/checklistGenerator.test.js`); merged to `main` with CI green |
+| Trip Persistence | Done | Trips are persisted to `data/trips.json` via server storage module; verified via Save → Refresh → Load demo path; merged to `main` with CI green |
+| Progress Tracking | Done | Checklist item state (`packed`) can be toggled and saved via `PUT /api/trips/{tripId}`; changes persist after refresh; merged to `main` with CI green |
+| Checklist Synchronization | Done | End-to-end sync verified: toggle packed item → refresh → state retained from server JSON persistence; merged to `main` with CI green |
+| Trip Retrieval | Done | `GET /api/trips` returns list of trips; `GET /api/trips/{tripId}` returns a single trip by ID; merged to `main` with CI green |
+
+Notes:
+- “Done” means merged into `main` with passing CI checks.
+- All tests run via `npm test` in CI.
+- Project board status matches repository reality (see Board Evidence link above).
 
 ---
 
@@ -49,25 +77,33 @@ If it is not listed in the MVP user stories, it will not be built.
 
 The demo will follow this exact path:
 
+**Total time: 5–7 minutes**
+
 1. Run `npm run dev:full`
 2. Open http://localhost:5173
-3. Open the application in the browser
-4. Create a new trip:
+3. Create a new trip:
    - Enter name
    - Select destination type
    - Enter duration
-5. Generate checklist
-6. Save trip to server
-7. Check off items
-8. Refresh browser
-9. Verify trip persists and progress is retained
-10. Show API endpoints working
+4. Click **Generate Checklist**
+5. Click **Save Trip**
+6. Confirm the trip is saved successfully
+7. Refresh the browser
+8. Verify saved trips load from the server
+9. Select a saved trip from the list
+10. Confirm the checklist renders correctly
+11. Check off an item
+12. Refresh again to confirm the packed state persists
 
-This demo proves:
-- Frontend → API → storage integration
-- Data persistence
+(Optional)
+13. Open http://localhost:3000/docs to show Swagger API documentation
+
+This demo demonstrates:
+- Frontend → API → JSON storage integration
+- Trip creation and persistence
+- Trip retrieval (list + by ID)
 - Checklist synchronization
-- End-to-end functionality
+- End-to-end MVP stability
 
 ---
 
@@ -89,22 +125,33 @@ This demo proves:
 
 ## Contract + Data Model Alignment
 
-API Endpoints:
+API Endpoints (MVP):
 - `GET /api/trips`
+- `GET /api/trips/{tripId}`
 - `POST /api/saveTrip`
 - `PUT /api/trips/{tripId}`
 
+Canonical Data Model (MVP)
+
 Trip Entity:
 {
-id,
-name,
-destinationType,
-duration,
-checklist[],
-createdAt
+  id,
+  name,
+  destinationType,
+  duration,
+  checklist[],
+  createdAt
+}
+
+Checklist Item Entity (canonical):
+{
+  id,
+  name,
+  category,
+  packed
 }
 
 Persistence:
 - Express.js server
-- JSON file storage (`data/trips.json`)
+- JSON file storage (`data/trips.json`) behind server storage module
 - No authentication layer


### PR DESCRIPTION
# Pull Request

## Summary

Updates /docs/mvp/scope-lock.md to reflect Week 7 MVP progress and repository reality.

- What was added/modified?
Added an MVP Story Status table (Done / evidence aligned to main)
Updated demo script outline to match the actual demo path
Confirmed board evidence link
Clarified definition of “Done” (merged to main with CI passing)
Updated API contract section to include GET /api/trips/{tripId}
Confirmed canonical data model for checklist items { id, name, category, packed }

- What problem does this address?
Ensures documentation matches the current state of the repository
Provides evidence of MVP progress for Week 7 checkpoint
Prevents scope drift by explicitly locking MVP stories
Aligns demo script with actual implemented functionality

## Why

Explain the motivation behind this change.

This change is part of the Week 7 MVP Build Sprint Checkpoint deliverable (Section A: MVP Progress Evidence).

It ensures:
MVP stories are clearly marked Done based on repository reality
“Done” aligns with merged PRs and passing CI
The demo script reflects what can actually be shown right now
Project board status matches the scope-lock documentation
This is a documentation alignment and accountability update — not a feature change.

## How to Verify

Provide clear steps to verify this change locally.

1. Install dependencies: `npm install`
2. Run the app: npm run dev:full
3. Confirm the demo path described in docs/mvp/scope-lock.md works:
Create a trip
Save trip
Refresh browser
Load saved trip
Select trip
Update checklist
Refresh and confirm persistence
4. Run tests: npm run eslint
5. Run tests: npm run test

Expected behavior:
All MVP stories listed as “Done” are functional in main
CI passes
Demo script matches actual app behavior
No new features beyond locked MVP scope

## Checklist (Definition of Done)

- Branch follows team naming pattern (`week<NUM>/<short-description>`)
- PR opened early and kept reviewable in size
- At least one teammate review requested
- CI checks are passing
- Lint passes locally (`npm run eslint`)
- Tests pass locally (`npm run test`)
- New behavior includes starter tests or test plan notes
- Documentation updated (docs/mvp/scope-lock.md)

## Notes for Reviewers

Feedback requested on:
Accuracy of MVP story statuses relative to main
Whether demo script reflects actual UI behavior
Whether definition of “Done” is clear and defensible
Any potential scope drift not caught in this update
Contract/data model alignment consistency

Goal: Ensure documentation accurately reflects repository state for the Week 7 checkpoint.