### PR TITLE
ci: always report required checks for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,47 +3,94 @@ name: CI Pipeline
 on:
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
- 
-  lint:
-    name: Code Linting
+  changes:
+    name: Detect Changed Files
     runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Detect docs-only change set
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            docs_only:
+              - 'docs/**'
+              - '**/*.md'
+              - '!**/*.js'
+              - '!**/*.mjs'
+              - '!**/*.cjs'
+              - '!**/*.ts'
+              - '!**/*.tsx'
+              - '!**/*.jsx'
+              - '!package.json'
+              - '!package-lock.json'
+              - '!pnpm-lock.yaml'
+              - '!yarn.lock'
+              - '!vite.config.*'
+              - '!vitest.config.*'
+              - '!eslint.config.*'
+              - '!server.js'
+              - '!src/**'
+              - '!.github/workflows/**'
+
+  lint:
+    name: Code Linting
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip lint for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Docs-only PR detected. Skipping lint run."
+
+      - name: Checkout code
+        if: needs.changes.outputs.docs_only != 'true'
+        uses: actions/checkout@v4
+
       - name: Setup Node
+        if: needs.changes.outputs.docs_only != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: npm ci
 
       - name: Run ESLint
+        if: needs.changes.outputs.docs_only != 'true'
         run: npm run eslint
 
   test:
     name: Unit Tests
-    needs: lint
+    needs: [changes, lint]
     runs-on: ubuntu-latest
     steps:
+      - name: Skip tests for docs-only PR
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Docs-only PR detected. Skipping unit tests."
+
       - name: Checkout code
+        if: needs.changes.outputs.docs_only != 'true'
         uses: actions/checkout@v4
 
       - name: Setup Node
+        if: needs.changes.outputs.docs_only != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: npm ci
 
       - name: Run Tests
+        if: needs.changes.outputs.docs_only != 'true'
         run: npm run test


### PR DESCRIPTION
## Summary
This updates the CI workflow so required check contexts (Code Linting and Unit Tests) always report on pull requests, including docs-only PRs.

## Problem
Our main-branch ruleset requires `Code Linting` and `Unit Tests`, but the previous workflow used `paths-ignore` for docs/markdown. For docs-only PRs, checks never started and PRs stayed blocked as "Expected - Waiting for status to be reported".

## Changes
- Remove PR-level `paths-ignore` so workflow always triggers.
- Add a `changes` job using `dorny/paths-filter` to detect docs-only changes.
- Keep `Code Linting` and `Unit Tests` job names unchanged (required contexts).
- Short-circuit lint/tests with fast pass steps when docs-only changes are detected.
- Run full lint/tests for non-docs changes as before.

## Result
- Docs-only PRs remain fast.
- Required status checks still report and satisfy branch rules.
- Non-docs PR behavior remains full CI coverage.
