### PR TITLE
ci: add workflow_dispatch trigger to deploy workflow

### DIFF
--- a/.github/workflows/deploy-eb.yaml
+++ b/.github/workflows/deploy-eb.yaml
@@ -15,6 +15,7 @@ jobs:
   deploy:
     name: Deploy to EB
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Adds manual trigger support to the CD workflow so deploys can be re-triggered without needing a code push. This also enables recovery when a deploy fails due to secret misconfiguration.