### PR TITLE
config: keep EBS_VOLUME_ID managed in EB environment only

### DIFF
--- a/.ebextensions/00_environment.config
+++ b/.ebextensions/00_environment.config
@@ -7,7 +7,8 @@ option_settings:
     # Path to the SQLite database file used in production.
     SQLITE_PATH: "/data/trips.db"
     # EBS volume ID for the persistent storage mount (set to the real value per environment).
-    EBS_VOLUME_ID: "REPLACE_IN_EB_ENV"
+    # The volume ID is currently static in the Elastic Beanstalk configuration for consistency since we won't have more than one deploy environment.
+    # EBS_VOLUME_ID: "REPLACE_IN_EB_ENV"
     # Sensitive values such as GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and SESSION_SECRET
     # must be configured per-environment via EB environment properties or a secrets manager
     # and are intentionally not defined here.


### PR DESCRIPTION
This updates .ebextensions/00_environment.config to keep EBS_VOLUME_ID commented out and documented as managed directly in Elastic Beanstalk environment properties.

Why:
- Prevents config deploys from overwriting the real EBS volume ID with a placeholder.
- Avoids breaking persistent SQLite storage on subsequent deployments.
- Matches our single hosted environment setup where the live value is already set in EB.

No runtime code changes; config/documentation-only update.