### PR TITLE
week13/remove-duplicate-edit-mode-UI-updates (Closes #126)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -116,16 +116,7 @@ function renderSavedTrips(trips, loadTrip, deleteTrip) {
     loadBtn.textContent = 'Load';
     loadBtn.type = 'button';
     loadBtn.addEventListener('click', () => {
-      const editingContext = document.getElementById('editing-context');
-      const saveTripBtn = document.getElementById('save-trip-btn');
-      if (editingContext) {
-        editingContext.textContent = `Editing: ${trip.name}`;
-        editingContext.hidden = false;
-      }
       loadTrip(trip);
-      if (saveTripBtn) {
-        saveTripBtn.textContent = 'Update Trip';
-      }
     });
 
     const deleteBtn = document.createElement('button');

--- a/src/tripForm.js
+++ b/src/tripForm.js
@@ -40,6 +40,22 @@ export function initTripForm({ onTripSaved } = {}) {
     generateChecklistBtn.textContent = isGeneratingChecklist ? 'Generating...' : 'Generate Checklist';
   }
 
+  function setSaveButtonForNewTrip() {
+    saveTripBtn.textContent = 'Save Trip';
+    saveTripBtn.disabled = true;
+  }
+
+  function setSaveButtonForEditing() {
+    saveTripBtn.textContent = 'Update Trip';
+    saveTripBtn.disabled = !hasChanges;
+  }
+
+  function hideEditingContext() {
+    if (!editingContext) return;
+    editingContext.textContent = '';
+    editingContext.hidden = true;
+  }
+
   function showEditingContext(tripName) {
     if (!editingContext) return;
     editingContext.textContent = `Editing: ${tripName}`;
@@ -56,6 +72,16 @@ export function initTripForm({ onTripSaved } = {}) {
       duration: form.elements['duration'].value || '',
       checklist: currentChecklist ? JSON.stringify(currentChecklist) : '',
     };
+  }
+
+  /**
+   * Update button disabled state based on whether there are changes
+   */
+  function updateButtonState() {
+    if (isEditingExistingTrip) {
+      saveTripBtn.disabled = !hasChanges;
+      return;
+    }
   }
 
   /**
@@ -76,15 +102,6 @@ export function initTripForm({ onTripSaved } = {}) {
     hasChanges = changed;
     updateButtonState();
     return changed;
-  }
-
-  /**
-   * Update button disabled state based on whether there are changes
-   */
-  function updateButtonState() {
-    if (isEditingExistingTrip) {
-      saveTripBtn.disabled = !hasChanges;
-    }
   }
 
   function debounce(fn, delay) {
@@ -115,23 +132,52 @@ export function initTripForm({ onTripSaved } = {}) {
     }, 400);
   }
 
-  function resetFormAfterCreateSave() {
+  function enterEditMode(trip) {
+    savedTripId = trip.id;
+    isEditingExistingTrip = true;
+    currentChecklist = structuredClone(trip.checklist || []);
+
+    form.elements['name'].value = trip.name || '';
+    form.elements['destinationType'].value = trip.destinationType || '';
+    form.elements['duration'].value = trip.duration || '';
+
+    checklistSection.hidden = currentChecklist.length === 0;
+
+    if (currentChecklist.length > 0) {
+      renderChecklist(currentChecklist);
+    } else if (checklistContainer) {
+      checklistContainer.innerHTML = '';
+    }
+
+    showEditingContext(trip.name);
+
+    originalFormState = captureFormState();
+    hasChanges = false;
+
+    setSaveButtonForEditing();
+    updateGenerateButtonState();
+  }
+
+  function exitEditModeAndResetForm() {
     form.reset();
     checklistSection.hidden = true;
+
     if (checklistContainer) checklistContainer.innerHTML = '';
     if (progressText) progressText.textContent = '';
 
+    currentChecklist = null;
+    savedTripId = null;
     isEditingExistingTrip = false;
     originalFormState = null;
     hasChanges = false;
-    currentChecklist = null;
-    savedTripId = null;
-    if (editingContext) {
-      editingContext.textContent = '';
-      editingContext.hidden = true;
-    }
-    saveTripBtn.disabled = true;
-    saveTripBtn.textContent = 'Save Trip';
+
+    hideEditingContext();
+    setSaveButtonForNewTrip();
+    updateGenerateButtonState();
+  }
+
+  function resetFormAfterCreateSave() {
+    exitEditModeAndResetForm();
   }
 
   const autoSaveChecklist = debounce(async (checklist) => {
@@ -151,7 +197,6 @@ export function initTripForm({ onTripSaved } = {}) {
     if (savedTripId) {
       autoSaveChecklist(checklist);
     }
-    // Check for changes whenever checklist is modified
     checkForChanges();
   });
 
@@ -160,32 +205,7 @@ export function initTripForm({ onTripSaved } = {}) {
    * @param {{ id: string, name: string, destinationType: string, duration: number, checklist: Array }} trip
    */
   function loadTrip(trip) {
-    form.elements['name'].value = trip.name || '';
-    form.elements['destinationType'].value = trip.destinationType || '';
-    form.elements['duration'].value = trip.duration || '';
-
-    savedTripId = trip.id;
-    isEditingExistingTrip = true;
-    currentChecklist = trip.checklist || [];
-
-    // Capture the initial state for change detection
-    originalFormState = captureFormState();
-    hasChanges = false;
-
-    showEditingContext(trip.name);
-
-    if (currentChecklist.length > 0) {
-      checklistSection.hidden = false;
-      renderChecklist(currentChecklist);
-      updateButtonState();
-    } else {
-      checklistSection.hidden = true;
-      saveTripBtn.disabled = true;
-    }
-
-    saveTripBtn.textContent = 'Update Trip';
-    updateButtonState();
-    updateGenerateButtonState();
+    enterEditMode(trip);
   }
 
   ['input', 'change'].forEach((eventName) => {
@@ -213,8 +233,6 @@ export function initTripForm({ onTripSaved } = {}) {
       flashChecklistUpdated();
 
       if (isEditingExistingTrip) {
-        saveTripBtn.textContent = 'Update Trip';
-        // Let checkForChanges() detect if the checklist actually changed
         checkForChanges();
       } else {
         saveTripBtn.textContent = 'Save Trip';
@@ -229,6 +247,8 @@ export function initTripForm({ onTripSaved } = {}) {
   form.addEventListener('input', checkForChanges);
 
   updateGenerateButtonState();
+  setSaveButtonForNewTrip();
+  hideEditingContext();
 
   saveTripBtn.addEventListener('click', async () => {
     const formData = new FormData(form);
@@ -246,12 +266,11 @@ export function initTripForm({ onTripSaved } = {}) {
     try {
       if (savedTripId) {
         await updateTripOnServer(savedTripId, tripData);
-        saveTripBtn.textContent = 'Trip Updated ✓';
         showToast('Trip updated successfully.', 'success');
-        // Reset change tracking after successful update
+
         originalFormState = captureFormState();
         hasChanges = false;
-        updateButtonState();
+        setSaveButtonForEditing();
       } else {
         const saved = await saveTripToServer(tripData);
         const savedId = saved.id;

--- a/tests/e2e/primary-workflow.spec.js
+++ b/tests/e2e/primary-workflow.spec.js
@@ -208,30 +208,32 @@ test.describe('Primary Workflow: Create and Save Trip', () => {
       return btn && !btn.disabled;
     });
 
-    // Button should show "Save Trip" for new trip
     await expect(saveBtn).toHaveText('Save Trip');
-
     await saveBtn.click();
 
     // Verify trip appears in saved list
     const tripRow = page.locator('#saved-trips-list li').filter({ hasText: tripName });
     await expect(tripRow).toHaveCount(1, { timeout: 10000 });
 
-    // Load the trip to verify button state changes
+    // Load the trip to verify edit-mode state
     const loadBtn = tripRow.first().locator('button:has-text("Load")');
     await loadBtn.click();
 
-    // Ensure load action has populated form values before checking context UI.
+    // Ensure load action has populated form values before checking context UI
     await expect(page.locator('#trip-name')).toHaveValue(tripName);
     await expect(page.locator('#destination-type')).toHaveValue('beach');
     await expect(page.locator('#duration')).toHaveValue('4');
 
-    // Verify editing context is displayed
     const editingContext = page.locator('#editing-context');
     await expect(editingContext).toHaveText(`Editing: ${tripName}`);
     await expect(editingContext).not.toHaveAttribute('hidden', '');
 
-    // Button should show "Update Trip" when editing
+    // Loaded edit mode should show Update Trip but remain disabled until a change is made
     await expect(saveBtn).toHaveText('Update Trip');
+    await expect(saveBtn).toBeDisabled();
+
+    // Make a real edit and confirm change detection enables update
+    await page.fill('#trip-name', `${tripName} Updated`);
+    await expect(saveBtn).toBeEnabled();
   });
 });


### PR DESCRIPTION
# Pull Request

## Summary

This PR fixes issue #126 : Flaky edit-mode UI after loading a saved trip by centralizing edit-mode UI ownership in `tripForm.js` and removing duplicated UI sync from `main.js`.

---

## Why

Previously, edit-mode UI state was managed in both `main.js` and `tripForm.js`, which caused:

- Inconsistent UI behavior after loading a trip  
- Race conditions between modules  
- Difficult-to-reason-about state transitions  

This PR resolves those issues by making `tripForm.js` the single source of truth for edit-mode behavior.

---

## What Changed

### 1. Removed duplicate edit-mode UI updates from src/main.js

- The saved trips Load button now only calls `loadTrip(trip)`  
- `main.js` no longer directly sets:
  - `#editing-context`  
  - `#save-trip-btn` text  

This removes split ownership of edit-mode state.

---

### 2. Centralized edit-mode state transitions in src/tripForm.js

Refactored logic so the form module controls:

- Entering edit mode  
- Exiting/resetting after new-trip save  
- Showing/hiding editing context  
- Setting save button text and disabled state  

Key helpers:

- `setSaveButtonForNewTrip()`  
- `setSaveButtonForEditing()`  
- `hideEditingContext()`  
- `showEditingContext()`  
- `enterEditMode(trip)`  
- `exitEditModeAndResetForm()`  

---

### 3. Simplified trip load behavior

`loadTrip(trip)` now delegates to `enterEditMode(trip)`.

Loading a trip consistently:

- Populates form fields  
- Clones checklist data  
- Renders the checklist  
- Shows "Editing: <trip name>"  
- Sets button text to "Update Trip"  
- Keeps the button disabled until a real change is made  

---

### 4. Preserved reset behavior after saving a new trip

The existing new-trip workflow remains intact:

- Form fields are cleared  
- Checklist is hidden  
- Editing context is cleared  
- Save button returns to "Save Trip"  

---

### 5. Strengthened regression coverage

Updated Playwright test for editing a saved trip to verify:

- Form values populate after load  
- Editing context is visible  
- Save button text becomes "Update Trip"  
- Save button is disabled immediately after load  
- Save button becomes enabled after an actual edit  

---

## How to Verify

### Manual verification

Start the app and log in.  

Create a new trip:

- Enter a trip name  
- Choose a destination type  
- Enter duration  
- Click Generate Checklist  

Confirm:

- Checklist appears  
- Save button says "Save Trip"  

Click Save Trip.  

Confirm after save:

- Form fields are cleared  
- Checklist section is hidden  
- Save button says "Save Trip"  
- Editing context is hidden  

In the saved trips list, click Load on the saved trip.  

Confirm:

- Form fields populate with saved values  
- Editing context shows "Editing: <trip name>"  
- Save button says "Update Trip"  
- Save button is disabled immediately after load  

Change one field (e.g., trip name).  

Confirm:

- Save button becomes enabled  

---

### Automated verification

Run targeted Playwright test:

npm exec playwright test tests/e2e/primary-workflow.spec.js --grep "button state and context display change when editing a saved trip"

Run full E2E suite:

npm run test:e2e  

Run all tests:

npm test  

---

## Expected Behavior

After clicking Load for a saved trip:

- `#editing-context` is visible and shows "Editing: <trip name>"  
- `#save-trip-btn` shows "Update Trip"  
- `#save-trip-btn` is disabled until the user makes a real change  

New trip behavior remains unchanged:

- Create → save → reset flow works normally  

---

## Checklist (Definition of Done)

- PR is focused and reviewable  
- Edit-mode state is centralized in `tripForm.js`  
- No duplicate UI state logic remains  
- Regression test updated and passing  
- No breaking changes to existing functionality  
- Verified locally  

---

## Notes for Reviewers

- This fix removes split ownership between `main.js` and `tripForm.js`  
- The new structure makes edit-mode behavior easier to reason about  
- Regression test coverage has been strengthened to prevent future issues  
- Please pay attention to:
  - State transitions when loading a trip  
  - Button enable/disable logic  
  - Any edge cases around partial edits  