### PR TITLE
Week 13: observability and support visibility improvements (#101)

### DIFF
--- a/docs/final/week13-observability.md
+++ b/docs/final/week13-observability.md
@@ -1,0 +1,91 @@
+# Week 13 Observability and Support Visibility
+
+Issue alignment: #101
+
+## Summary
+Week 13 observability work focused on making failures easier to diagnose, making request behavior easier to trace, and clarifying how logging behaves across local and hosted environments.
+
+## Improvement 1: Request Correlation IDs and Access Logging
+### Blind spot addressed
+Before this change, it was hard to correlate user-reported failures to specific backend events because request IDs were not consistently surfaced in API responses and route-level context was fragmented.
+
+### What changed
+- Added request ID middleware that reuses incoming `x-request-id` when present, or generates one when missing.
+- Added `x-request-id` response header for all requests.
+- Added structured request completion logs (`HTTP_REQUEST`) with method, path, status code, latency, and user ID when available.
+- **PR review follow-up (2787613):** Request IDs from client headers are now sanitized — only alphanumeric characters plus `.`, `_`, `-` are accepted, with a 128-character maximum. Malformed or oversized values are replaced with a server-generated UUID.
+- **PR review follow-up (2787613):** Request completion logs now use `req.path` instead of `req.url` to avoid leaking query-string parameters (tokens, PII) into log files.
+
+### Where it applies
+- Express middleware in `server.js`.
+- All API endpoints, including authenticated and unauthenticated responses.
+
+### Support value
+Maintainers can now trace a single failing request end-to-end using request ID values from client responses, server logs, and error logs.
+
+## Improvement 2: Health and Diagnostics Visibility
+### Blind spot addressed
+Health checks previously gave limited operational context and did not expose enough diagnostics for fast triage in non-production environments.
+
+### What changed
+- Expanded `/health` payload with:
+  - `requestId`
+  - `uptimeSeconds`
+  - `version`
+  - config validity indicator (`config.valid`)
+- In non-production environments, health now reports missing startup config keys for faster debugging.
+
+### Where it applies
+- `GET /health` response behavior in `server.js`.
+
+### Support value
+Operators get a faster first-pass diagnosis of environment and configuration state without deep code inspection.
+
+## Improvement 3: Startup Validation and Centralized Error Visibility
+### Blind spot addressed
+Misconfigured environments could fail later and less clearly, and not-found/unhandled errors did not consistently return correlation information.
+
+### What changed
+- Added startup config validation with explicit fail-fast error messages for missing critical environment keys.
+- Added centralized JSON 404 handler with `requestId`.
+- Added centralized unhandled error middleware that logs structured `UNHANDLED_ERROR` entries and returns `requestId` in 500 responses.
+
+### Where it applies
+- Server startup path and global Express handlers in `server.js`.
+
+### Support value
+Misconfiguration is detected immediately at boot, and runtime failures become easier to correlate and diagnose in production support workflows.
+
+## Hosted vs Local Logging Behavior (Explicit Operational Note)
+### Hosted (production)
+- Logs are emitted to console as structured JSON via Winston Console transport.
+- In hosted infrastructure, these are viewed in platform log aggregation (for example, Elastic Beanstalk instance logs/CloudWatch streams).
+- The application does not write production logs to the repository `logs/` folder by default.
+
+### Local development and test
+- Logs are written to `logs/app.log` with rotation settings.
+- Logs are also displayed in the local terminal in a colorized timestamped format for developer debugging.
+
+## Before/After Notes
+- Before: Hard to trace request-specific incidents across endpoints.
+- After: Request IDs are propagated and returned to clients for direct correlation.
+
+- Before: Health output gave less context for support triage.
+- After: Health output includes diagnostics and config validity information.
+
+- Before: Some failures surfaced without consistent structured error context.
+- After: Not-found and unhandled errors include correlation IDs and structured logs.
+
+## Test Evidence
+Automated coverage added/updated in server tests verifies:
+- request ID propagation and response header parity
+- request ID reuse from caller-provided header
+- malformed or oversized request IDs are replaced with a server-generated UUID
+- request ID presence in 404 error responses
+
+Full test suite: 35/35 passing (`npm test -- tests/server.test.js`).
+
+## PR Evidence
+- PR: [#133 — Week 13: observability and support visibility improvements (#101)](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-4/pull/133)
+- Commits: `e0b9c21` (initial observability improvements), `2787613` (PR review: sanitize request IDs and redact query logging)
+- CI run: [All checks passing](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-4/actions/runs/24173758675) (Unit Tests, E2E Tests, Code Linting)

--- a/server.js
+++ b/server.js
@@ -35,31 +35,54 @@ const appVersion = process.env.npm_package_version || 'unknown';
 const __filename = fileURLToPath(import.meta.url);
 const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === __filename;
 
+const MAX_REQUEST_ID_LENGTH = 128;
+const REQUEST_ID_HEADER_VALUE_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+function isMissingConfigValue(key) {
+  const value = process.env[key];
+  return typeof value !== 'string' || value.trim() === '';
+}
+
+function getRequiredStartupConfigKeys() {
+  const required = [];
+
+  if (!isTest) {
+    required.push('GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET');
+  }
+
+  if (isProduction) {
+    required.push('SESSION_SECRET', 'SQLITE_PATH');
+  }
+
+  return required;
+}
+
+function getSafeRequestId(value) {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_REQUEST_ID_LENGTH ||
+    !REQUEST_ID_HEADER_VALUE_PATTERN.test(value)
+  ) {
+    return uuidv4();
+  }
+
+  return value;
+}
+
 function resolveRequestId(req) {
   if (req.requestId) return req.requestId;
 
   const headerRequestId = req.headers['x-request-id'];
-  if (typeof headerRequestId === 'string' && headerRequestId.trim()) {
-    return headerRequestId.trim();
+  if (typeof headerRequestId === 'string') {
+    return getSafeRequestId(headerRequestId.trim());
   }
 
   return uuidv4();
 }
 
 function getMissingStartupConfigKeys() {
-  const missing = [];
-
-  if (!isTest) {
-    if (!process.env.GOOGLE_CLIENT_ID) missing.push('GOOGLE_CLIENT_ID');
-    if (!process.env.GOOGLE_CLIENT_SECRET) missing.push('GOOGLE_CLIENT_SECRET');
-  }
-
-  if (isProduction) {
-    if (!process.env.SESSION_SECRET) missing.push('SESSION_SECRET');
-    if (!process.env.SQLITE_PATH) missing.push('SQLITE_PATH');
-  }
-
-  return missing;
+  return getRequiredStartupConfigKeys().filter((key) => isMissingConfigValue(key));
 }
 
 function validateStartupConfig() {
@@ -222,7 +245,7 @@ app.use((req, res, next) => {
       status: 'COMPLETE',
       details: {
         method: req.method,
-        path: req.originalUrl,
+        path: req.path,
         statusCode: res.statusCode,
         durationMs: Number(durationMs.toFixed(2)),
         userId: req.user?.id || null,
@@ -624,7 +647,7 @@ app.use(async (error, req, res, next) => {
   const requestId = resolveRequestId(req);
   await log(requestId, 'UNHANDLED_ERROR', 'ERROR', {
     method: req.method,
-    path: req.originalUrl,
+    path: req.path,
     reason: error.message,
     errorType: error.constructor?.name,
     stack: error.stack?.split('\n').slice(0, 3),

--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ import {
 import { requireAuth, resolveAuthenticatedUser, isTestModeRequest } from './server/auth.js';
 import swaggerUi from 'swagger-ui-express';
 import YAML from 'yamljs';
-import { log } from './server/logger.js';
+import { log, logger } from './server/logger.js';
 import { v4 as uuidv4 } from 'uuid';
 import passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
@@ -31,8 +31,46 @@ const PORT = process.env.PORT || 3000;
 const isTest = process.env.NODE_ENV === 'test';
 const isProduction = process.env.NODE_ENV === 'production';
 const distDir = path.resolve(process.cwd(), 'dist');
+const appVersion = process.env.npm_package_version || 'unknown';
 const __filename = fileURLToPath(import.meta.url);
 const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+
+function resolveRequestId(req) {
+  if (req.requestId) return req.requestId;
+
+  const headerRequestId = req.headers['x-request-id'];
+  if (typeof headerRequestId === 'string' && headerRequestId.trim()) {
+    return headerRequestId.trim();
+  }
+
+  return uuidv4();
+}
+
+function getMissingStartupConfigKeys() {
+  const missing = [];
+
+  if (!isTest) {
+    if (!process.env.GOOGLE_CLIENT_ID) missing.push('GOOGLE_CLIENT_ID');
+    if (!process.env.GOOGLE_CLIENT_SECRET) missing.push('GOOGLE_CLIENT_SECRET');
+  }
+
+  if (isProduction) {
+    if (!process.env.SESSION_SECRET) missing.push('SESSION_SECRET');
+    if (!process.env.SQLITE_PATH) missing.push('SQLITE_PATH');
+  }
+
+  return missing;
+}
+
+function validateStartupConfig() {
+  const missingKeys = getMissingStartupConfigKeys();
+  if (missingKeys.length === 0) return;
+
+  throw new Error(
+    `Missing required configuration: ${missingKeys.join(', ')}. ` +
+      'Update your environment variables before starting the server.',
+  );
+}
 
 function getConfiguredDbPath() {
   if (isTest) return ':memory:';
@@ -168,13 +206,44 @@ if (!isTest) {
 
 app.use(express.json());
 
+// Correlate request/response logs and surface request IDs to clients for support debugging.
+app.use((req, res, next) => {
+  const requestId = resolveRequestId(req);
+  req.requestId = requestId;
+  res.setHeader('x-request-id', requestId);
+
+  const startedAt = process.hrtime.bigint();
+  res.on('finish', () => {
+    const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    logger.info({
+      timestamp: new Date().toISOString(),
+      requestId,
+      action: 'HTTP_REQUEST',
+      status: 'COMPLETE',
+      details: {
+        method: req.method,
+        path: req.originalUrl,
+        statusCode: res.statusCode,
+        durationMs: Number(durationMs.toFixed(2)),
+        userId: req.user?.id || null,
+      },
+    });
+  });
+
+  next();
+});
+
 app.get('/health', (req, res) => {
   const dbStatus = getDbPathStatus();
   const statusCode = dbStatus.writable ? 200 : 503;
+  const missingConfig = getMissingStartupConfigKeys();
 
   const baseResponse = {
     status: dbStatus.writable ? 'ok' : 'degraded',
     environment: process.env.NODE_ENV || 'development',
+    version: appVersion,
+    requestId: resolveRequestId(req),
+    uptimeSeconds: Math.floor(process.uptime()),
   };
 
   // In production, avoid exposing internal filesystem paths or low-level errors.
@@ -184,11 +253,18 @@ app.get('/health', (req, res) => {
         database: {
           writable: dbStatus.writable,
         },
+        config: {
+          valid: missingConfig.length === 0,
+        },
       }
     : {
         ...baseResponse,
         // In non-production, include full database status for easier debugging.
         database: dbStatus,
+        config: {
+          valid: missingConfig.length === 0,
+          missing: missingConfig,
+        },
       };
 
   res.status(statusCode).json(responseBody);
@@ -235,6 +311,7 @@ app.get('/auth/logout', (req, res, next) => {
 });
 
 app.get('/auth/user', async (req, res) => {
+  const requestId = resolveRequestId(req);
   try {
     const user = await resolveAuthenticatedUser(req);
 
@@ -245,14 +322,18 @@ app.get('/auth/user', async (req, res) => {
 
     return res.status(401).json({ error: 'Not authenticated' });
   } catch (error) {
-    console.error('Error in /auth/user:', error);
-    return res.status(500).json({ error: 'Internal server error' });
+    await log(requestId, 'AUTH_USER', 'ERROR', {
+      reason: error.message,
+      errorType: error.constructor?.name,
+      stack: error.stack?.split('\n').slice(0, 3),
+    });
+    return res.status(500).json({ error: 'Internal server error', requestId });
   }
 });
 
 // GET /api/trips - List all trips
 app.get('/api/trips', requireAuth, async (req, res) => {
-  const requestId = req.headers['x-request-id'] || uuidv4();
+  const requestId = resolveRequestId(req);
   try {
     await log(requestId, 'GET_TRIPS', 'START');
     const trips = await getAllTrips(req.user.id);
@@ -270,7 +351,7 @@ app.get('/api/trips', requireAuth, async (req, res) => {
 
 // GET /api/trips/:tripId - Get a single trip by ID
 app.get('/api/trips/:tripId', requireAuth, async (req, res) => {
-  const requestId = req.headers['x-request-id'] || uuidv4();
+  const requestId = resolveRequestId(req);
   const { tripId } = req.params;
 
   try {
@@ -305,7 +386,7 @@ app.get('/api/trips/:tripId', requireAuth, async (req, res) => {
 
 // POST /api/saveTrip - Create new trip with checklist
 app.post('/api/saveTrip', requireAuth, async (req, res) => {
-  const requestId = req.headers['x-request-id'] || uuidv4();
+  const requestId = resolveRequestId(req);
 
   try {
     const { name, destinationType, duration, checklist } = req.body;
@@ -403,7 +484,7 @@ app.post('/api/saveTrip', requireAuth, async (req, res) => {
 
 // PUT /api/trips/:tripId - Update trip with checklist
 app.put('/api/trips/:tripId', requireAuth, async (req, res) => {
-  const requestId = req.headers['x-request-id'] || uuidv4();
+  const requestId = resolveRequestId(req);
   const { tripId } = req.params;
 
   try {
@@ -499,13 +580,23 @@ app.put('/api/trips/:tripId', requireAuth, async (req, res) => {
 
 // DELETE /api/trips/:tripId - Delete a trip
 app.delete('/api/trips/:tripId', requireAuth, async (req, res) => {
+  const requestId = resolveRequestId(req);
   try {
     await deleteTrip(req.params.tripId, req.user.id);
     res.status(204).end();
   } catch (error) {
     if (error.code === 'TRIP_NOT_FOUND') {
+      await log(requestId, 'DELETE_TRIP', 'NOT_FOUND', {
+        tripId: req.params.tripId,
+      });
       return res.status(404).json({ error: 'Trip not found' });
     }
+    await log(requestId, 'DELETE_TRIP', 'ERROR', {
+      tripId: req.params.tripId,
+      reason: error.message,
+      errorType: error.constructor?.name,
+      stack: error.stack?.split('\n').slice(0, 3),
+    });
     res.status(500).json({ error: 'Failed to delete trip' });
   }
 });
@@ -525,10 +616,36 @@ if (isProduction) {
   });
 }
 
+app.use((req, res) => {
+  res.status(404).json({ error: 'Not found', requestId: resolveRequestId(req) });
+});
+
+app.use(async (error, req, res, next) => {
+  const requestId = resolveRequestId(req);
+  await log(requestId, 'UNHANDLED_ERROR', 'ERROR', {
+    method: req.method,
+    path: req.originalUrl,
+    reason: error.message,
+    errorType: error.constructor?.name,
+    stack: error.stack?.split('\n').slice(0, 3),
+  });
+
+  if (res.headersSent) {
+    return next(error);
+  }
+
+  return res.status(500).json({
+    error: 'Internal server error',
+    requestId,
+  });
+});
+
 // Export app for testing
 export { app };
 
 if (isDirectRun) {
+  validateStartupConfig();
+
   if (isProduction) {
     ensureProductionStorageReady();
   }
@@ -536,15 +653,24 @@ if (isDirectRun) {
   await migrateLatest();
 
   app.listen(PORT, () => {
-    console.log(`Trip Manager API running on http://localhost:${PORT}`);
-    console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
-    console.log(`SQLite path: ${getConfiguredDbPath()}`);
-    console.log('Endpoints:');
-    console.log('  GET    /health');
-    console.log('  GET    /api/trips');
-    console.log('  GET    /api/trips/{tripId}');
-    console.log('  POST   /api/saveTrip');
-    console.log('  PUT    /api/trips/{tripId}');
-    console.log('  DELETE /api/trips/{tripId}');
+    logger.info({
+      timestamp: new Date().toISOString(),
+      action: 'SERVER_START',
+      status: 'SUCCESS',
+      details: {
+        url: `http://localhost:${PORT}`,
+        environment: process.env.NODE_ENV || 'development',
+        sqlitePath: getConfiguredDbPath(),
+        version: appVersion,
+        endpoints: [
+          'GET /health',
+          'GET /api/trips',
+          'GET /api/trips/{tripId}',
+          'POST /api/saveTrip',
+          'PUT /api/trips/{tripId}',
+          'DELETE /api/trips/{tripId}',
+        ],
+      },
+    });
   });
 }

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -91,6 +91,20 @@ describe('Observability behavior', () => {
     expect(res.body.requestId).toBe(requestId);
   });
 
+  it('sanitizes invalid x-request-id values before echoing response headers', async () => {
+    const invalidRequestId = 'x'.repeat(200);
+
+    const res = await request(app)
+      .get('/health')
+      .set('x-request-id', invalidRequestId);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-request-id']).not.toBe(invalidRequestId);
+    expect(res.headers['x-request-id']).toBe(res.body.requestId);
+    expect(res.headers['x-request-id'].length).toBeLessThanOrEqual(128);
+    expect(res.headers['x-request-id']).toMatch(/^[A-Za-z0-9._-]+$/);
+  });
+
   it('returns requestId in not-found responses', async () => {
     const res = await request(app).get('/route-that-does-not-exist');
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -52,8 +52,13 @@ describe('Authentication enforcement', () => {
     expect(res.status).toBe(200);
     expect(res.body.status).toBe('ok');
     expect(res.body.environment).toBe('test');
+    expect(typeof res.body.requestId).toBe('string');
+    expect(res.body.requestId.length).toBeGreaterThan(0);
+    expect(typeof res.body.uptimeSeconds).toBe('number');
+    expect(res.body.config.valid).toBe(true);
     expect(res.body.database.path).toBe(':memory:');
     expect(res.body.database.writable).toBe(true);
+    expect(res.headers['x-request-id']).toBe(res.body.requestId);
   });
 
   it('returns 401 when GET /api/trips is called without auth', async () => {
@@ -69,6 +74,31 @@ describe('Authentication enforcement', () => {
       checklist: [],
     });
     expect(res.status).toBe(401);
+    expect(typeof res.headers['x-request-id']).toBe('string');
+  });
+});
+
+describe('Observability behavior', () => {
+  it('reuses caller-provided x-request-id for correlation', async () => {
+    const requestId = 'obs-test-request-id-123';
+
+    const res = await request(app)
+      .get('/health')
+      .set('x-request-id', requestId);
+
+    expect(res.status).toBe(200);
+    expect(res.headers['x-request-id']).toBe(requestId);
+    expect(res.body.requestId).toBe(requestId);
+  });
+
+  it('returns requestId in not-found responses', async () => {
+    const res = await request(app).get('/route-that-does-not-exist');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Not found');
+    expect(typeof res.body.requestId).toBe('string');
+    expect(res.body.requestId.length).toBeGreaterThan(0);
+    expect(res.headers['x-request-id']).toBe(res.body.requestId);
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Summary

Implemented Week 13 observability and support-visibility backend improvements.

- Added request correlation support by propagating `x-request-id` across requests/responses.
- Added structured HTTP request completion logging (method, path, status, duration, userId when available).
- Added startup configuration validation with fail-fast errors for missing required environment keys.
- Expanded `/health` diagnostics with requestId, uptime, version, and config validity metadata.
- Added centralized JSON 404 and unhandled error middleware with requestId for faster incident correlation.
- Added/updated server tests to cover request-id propagation and 404 diagnostics behavior.

This addresses issue #101 by making failures easier to detect, trace, and diagnose in both hosted and local environments.

## Why

- Yes, this is part of the Week 13 deliverable C (Observability + Support Visibility).
- This is an architectural/supportability improvement focused on maintainability and operations readiness.

## How to Verify

1. Install dependencies: `npm install`
2. Run lint: `npm run eslint`
3. Run tests: `npm run test`
4. (Optional manual runtime check) start server and inspect logs:
   - Local: `npm run server`
   - Hit `GET /health` and one API route; verify `x-request-id` is returned and request logs include `HTTP_REQUEST` entries.
5. Expected behavior:
   - API responses include `x-request-id`.
   - Unknown routes return JSON `{ error: "Not found", requestId: ... }`.
   - `/health` includes diagnostics (`requestId`, `uptimeSeconds`, `version`, config validity).
   - Logs are structured and request-correlated.

## Checklist (Definition of Done)

- [x] Branch follows team naming pattern (`week<NUM>/<short-description>`)
- [x] PR opened early and kept reviewable in size
- [ ] At least one teammate review requested
- [ ] CI checks are passing
- [x] Lint passes locally (`npm run eslint`)
- [x] Tests pass locally (`npm run test`)
- [x] New behavior includes starter tests or test plan notes
- [x] Documentation updated if needed (`README`, `docs/`, ADRs)

## Notes for Reviewers

Please focus feedback on:
- Whether startup validation scope is appropriately strict for non-test environments.
- Whether the request-id/error response shape is sufficient for support workflows.
- Any concerns about middleware ordering for logging vs auth population.