### PR TITLE
Week 14 Deliverable D: API documentation

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,194 @@
+# API & Interface Documentation
+
+## OpenAPI specification
+
+The canonical API reference is [`openapi.yaml`](openapi.yaml) (OpenAPI 3.0.3).
+
+### Viewing interactively
+
+When the server is running, Swagger UI is served at:
+
+```
+http://localhost:3000/docs       # development
+https://spcg.zentrofi.com/docs   # production
+```
+
+## Authentication flow
+
+All `/api/*` routes require a valid session. The authentication sequence is:
+
+1. **Browser** navigates to `GET /auth/google`
+2. **Server** redirects (302) to Google OAuth consent screen
+3. **Google** redirects back to `GET /auth/google/callback` with an authorization code
+4. **Server** exchanges the code for a user profile, upserts the user in the database, establishes a session, and redirects to `FRONTEND_URL`
+5. Subsequent requests include the `connect.sid` session cookie automatically
+
+To check the current session: `GET /auth/user` — returns the `User` object or `401`.
+
+To log out: `GET /auth/logout` — destroys the session and clears the cookie.
+
+## API endpoints summary
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/health` | No | System health and readiness check |
+| GET | `/auth/google` | No | Initiate Google OAuth login (302 redirect) |
+| GET | `/auth/google/callback` | No | OAuth callback (302 redirect) |
+| GET | `/auth/login-error` | No | OAuth failure redirect |
+| GET | `/auth/logout` | Session | Log out, destroy session |
+| GET | `/auth/user` | Session | Get current authenticated user |
+| GET | `/api/trips` | Session | List all trips for the user |
+| POST | `/api/saveTrip` | Session | Create a new trip |
+| GET | `/api/trips/{tripId}` | Session | Get a single trip |
+| PUT | `/api/trips/{tripId}` | Session | Update a trip (partial) |
+| DELETE | `/api/trips/{tripId}` | Session | Delete a trip |
+
+## Example requests
+
+### Check system health
+
+```bash
+curl http://localhost:3000/health
+```
+
+```json
+{
+  "status": "ok",
+  "environment": "development",
+  "version": "1.0.0",
+  "requestId": "req-abc123",
+  "uptimeSeconds": 3600,
+  "database": { "writable": true, "path": "./data/trips.db", "target": "./data", "error": null },
+  "config": { "valid": true, "missing": [] }
+}
+```
+
+### Create a trip (authenticated)
+
+```bash
+curl -X POST http://localhost:3000/api/saveTrip \
+  -H "Content-Type: application/json" \
+  -b "connect.sid=<session-cookie>" \
+  -d '{
+    "name": "Beach Getaway",
+    "destinationType": "beach",
+    "duration": 5,
+    "checklist": [
+      { "id": "item-0", "name": "Sunscreen", "category": "Beach", "packed": false }
+    ]
+  }'
+```
+
+### List trips (authenticated)
+
+```bash
+curl http://localhost:3000/api/trips \
+  -b "connect.sid=<session-cookie>"
+```
+
+## Request lifecycle
+
+A typical authenticated API request flows through the following stages:
+
+```
+Browser
+  │
+  │  HTTP request with connect.sid cookie
+  ▼
+Express server (server.js)
+  │
+  ├─ 1. Request ID middleware
+  │     Reads X-Request-Id header or generates a UUID.
+  │     Attaches requestId to the request for logging.
+  │
+  ├─ 2. Session middleware (express-session)
+  │     Deserializes the session from the connect.sid cookie.
+  │     Passport restores req.user via getUserById().
+  │
+  ├─ 3. JSON body parser (express.json)
+  │     Parses request body for POST/PUT routes.
+  │
+  ├─ 4. Request logger
+  │     Logs method, path, and timing via Winston.
+  │
+  ├─ 5. Route handler
+  │     │
+  │     ├─ requireAuth middleware
+  │     │   Calls resolveAuthenticatedUser(req).
+  │     │   Returns 401 if no valid session.
+  │     │
+  │     ├─ Input validation
+  │     │   Trims strings, checks required fields, validates
+  │     │   checklist item structure. Returns 400 on failure.
+  │     │
+  │     └─ Storage layer (server/storage.js)
+  │         Executes Knex query against SQLite.
+  │         Returns domain object (Trip, User).
+  │
+  ▼
+JSON response → Browser
+```
+
+For unauthenticated routes (`/health`, `/auth/*`), steps 2 and 5's `requireAuth` are skipped.
+
+## External integrations
+
+| Integration | Purpose | Configuration |
+|-------------|---------|---------------|
+| **Google OAuth 2.0 API** | User authentication. The server exchanges authorization codes for user profiles via Passport.js `GoogleStrategy`. | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL`. OAuth consent screen and redirect URIs must be configured in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials). |
+| **SQLite via better-sqlite3** | Persistent storage for users, trips, and checklist items. Accessed through Knex.js query builder with migration support. | `SQLITE_PATH` (production). In development, defaults to `./data/trips.db`. In production, the database file lives on a mounted EBS volume at `/data/trips.db`. |
+| **Winston file transport** | Structured JSON logging to `logs/app.log`. Each log entry includes the `requestId` for request tracing. Console transport is added in non-production environments. | No external configuration. Log directory is created automatically. |
+
+## Internal services
+
+The server is composed of several internal modules. These are not HTTP APIs, but they define the major architectural boundaries.
+
+### Data layer — `server/storage.js`
+
+Manages all database access via [Knex.js](https://knexjs.org/) with better-sqlite3.
+
+| Function | Purpose |
+|----------|---------|
+| `migrateLatest()` | Run pending Knex migrations |
+| `getAllTrips(userId)` | Fetch all trips owned by a user (newest first) |
+| `getTripById(tripId, userId)` | Fetch one trip (ownership-scoped) |
+| `createTrip(params)` | Insert a trip + checklist items in a transaction |
+| `updateTrip(tripId, updates, userId)` | Partial update of trip fields + checklist replacement |
+| `deleteTrip(tripId, userId)` | Delete a trip and its checklist items |
+| `findOrCreateUser(profile)` | Upsert a user from a Google OAuth profile |
+| `getUserById(id)` | Fetch a user row by primary key |
+
+Database file: `./data/trips.db` (development) or `$SQLITE_PATH` (production, on mounted EBS volume).
+
+### Auth middleware — `server/auth.js`
+
+| Export | Purpose |
+|--------|---------|
+| `requireAuth(req, res, next)` | Express middleware — resolves the user or returns 401 |
+| `resolveAuthenticatedUser(req)` | Returns the user from session or test headers |
+| `isTestModeRequest(req)` | True when `NODE_ENV=test` and `x-test-user-id` header is present |
+
+In test mode, `resolveAuthenticatedUser` auto-creates a test user from the `x-test-user-id` header, bypassing Google OAuth entirely.
+
+### Logger — `server/logger.js`
+
+Structured logging via [Winston](https://github.com/winstonjs/winston). Every request is assigned a `requestId` (from the `X-Request-Id` header or auto-generated) that propagates through all log entries for that request.
+
+Log output: `logs/app.log` (file) + stdout (console in development).
+
+### Checklist generator — `src/checklistGenerator.js`
+
+Client-side module that generates packing checklist items based on destination type and trip duration. This is a pure function with no server dependency — it runs in the browser.
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GOOGLE_CLIENT_ID` | Production, development | — | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | Production, development | — | Google OAuth client secret |
+| `GOOGLE_CALLBACK_URL` | Production | `http://localhost:3000/auth/google/callback` | OAuth redirect URI |
+| `SESSION_SECRET` | Production | `default-dev-secret-...` | Express session signing secret |
+| `FRONTEND_URL` | Optional | `http://localhost:5173` | Post-login redirect target |
+| `SQLITE_PATH` | Production | — | Absolute path to SQLite database file |
+| `NODE_ENV` | Optional | `development` | `development`, `production`, or `test` |
+| `PORT` | Optional | `3000` | HTTP listen port |

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -35,7 +35,7 @@ To log out: `GET /auth/logout` — destroys the session and clears the cookie.
 | GET | `/auth/google` | No | Initiate Google OAuth login (302 redirect) |
 | GET | `/auth/google/callback` | No | OAuth callback (302 redirect) |
 | GET | `/auth/login-error` | No | OAuth failure redirect |
-| GET | `/auth/logout` | Session | Log out, destroy session |
+| GET | `/auth/logout` | No | Log out, destroy session (no-op if not logged in) |
 | GET | `/auth/user` | Session | Get current authenticated user |
 | GET | `/api/trips` | Session | List all trips for the user |
 | POST | `/api/saveTrip` | Session | Create a new trip |
@@ -135,9 +135,9 @@ For unauthenticated routes (`/health`, `/auth/*`), steps 2 and 5's `requireAuth`
 
 | Integration | Purpose | Configuration |
 |-------------|---------|---------------|
-| **Google OAuth 2.0 API** | User authentication. The server exchanges authorization codes for user profiles via Passport.js `GoogleStrategy`. | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALLBACK_URL`. OAuth consent screen and redirect URIs must be configured in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials). |
+| **Google OAuth 2.0 API** | User authentication. The server exchanges authorization codes for user profiles via Passport.js `GoogleStrategy`. | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`. The OAuth consent screen and the authorized redirect URI (`/auth/google/callback`) must be configured in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials). |
 | **SQLite via better-sqlite3** | Persistent storage for users, trips, and checklist items. Accessed through Knex.js query builder with migration support. | `SQLITE_PATH` (production). In development, defaults to `./data/trips.db`. In production, the database file lives on a mounted EBS volume at `/data/trips.db`. |
-| **Winston file transport** | Structured JSON logging to `logs/app.log`. Each log entry includes the `requestId` for request tracing. Console transport is added in non-production environments. | No external configuration. Log directory is created automatically. |
+| **Winston logging** | Structured logging with environment-specific transports. In production, logs are emitted as JSON to the console only. In non-production, logs are written to `logs/app.log` and also printed to the console with pretty formatting. Each log entry includes the `requestId` for request tracing. | No external configuration. In non-production, the log directory is created automatically for the file transport. |
 
 ## Internal services
 
@@ -174,7 +174,7 @@ In test mode, `resolveAuthenticatedUser` auto-creates a test user from the `x-te
 
 Structured logging via [Winston](https://github.com/winstonjs/winston). Every request is assigned a `requestId` (from the `X-Request-Id` header or auto-generated) that propagates through all log entries for that request.
 
-Log output: `logs/app.log` (file) + stdout (console in development).
+Log output: non-production writes to `logs/app.log` and stdout (pretty-formatted). Production writes JSON to stdout only.
 
 ### Checklist generator — `src/checklistGenerator.js`
 
@@ -186,8 +186,7 @@ Client-side module that generates packing checklist items based on destination t
 |----------|----------|---------|-------------|
 | `GOOGLE_CLIENT_ID` | Production, development | — | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | Production, development | — | Google OAuth client secret |
-| `GOOGLE_CALLBACK_URL` | Production | `http://localhost:3000/auth/google/callback` | OAuth redirect URI |
-| `SESSION_SECRET` | Production | `default-dev-secret-...` | Express session signing secret |
+| `SESSION_SECRET` | Production | `default-dev-secret-change-in-production` (development only) | Express session signing secret. Startup throws in production if unset. |
 | `FRONTEND_URL` | Optional | `http://localhost:5173` | Post-login redirect target |
 | `SQLITE_PATH` | Production | — | Absolute path to SQLite database file |
 | `NODE_ENV` | Optional | `development` | `development`, `production`, or `test` |

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -237,6 +237,10 @@ components:
         success:
           type: boolean
           example: true
+        testMode:
+          type: boolean
+          description: Present only when the request is made in test mode (NODE_ENV=test with the x-test-user-id header).
+          example: true
 
 security:
   - SessionAuth: []
@@ -323,7 +327,9 @@ paths:
       summary: Log out the current user
       description: |
         Destroys the server session, clears the `connect.sid` cookie,
-        and returns a success response.
+        and returns a success response. This route does not require an
+        active session and will return 200 even if the caller is not logged in.
+      security: []
       responses:
         '200':
           description: Logout successful

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,13 +1,20 @@
 openapi: 3.0.3
 info:
   title: Smart Packing Checklist Generator API
-  version: 1.0.0
+  version: 1.1.0
   description: |
-    REST API for authenticated users to create, read, update, and delete their own trips
-    and packing checklist items.
+    REST API for the Smart Packing Checklist Generator. Covers authentication
+    (Google OAuth), health monitoring, and CRUD operations on user-owned trips
+    and packing checklists.
+
+    **Authentication flow:** Browser navigates to `/auth/google` → Google consent
+    → callback sets `connect.sid` session cookie → all `/api/*` requests use that cookie.
 
 servers:
   - url: http://localhost:3000
+    description: Local development
+  - url: https://spcg.zentrofi.com
+    description: Production (AWS Elastic Beanstalk)
 
 components:
   securitySchemes:
@@ -70,6 +77,98 @@ components:
           format: date-time
           example: 2026-02-22T12:34:56.789Z
 
+    User:
+      type: object
+      required:
+        - id
+        - google_id
+        - email
+        - name
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
+        google_id:
+          type: string
+          example: "117234567890123456789"
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        name:
+          type: string
+          example: Jane Doe
+        picture:
+          type: string
+          nullable: true
+          format: uri
+          example: https://lh3.googleusercontent.com/a/photo
+        created_at:
+          type: string
+          format: date-time
+          example: 2026-03-01T10:00:00.000Z
+
+    HealthResponse:
+      type: object
+      required:
+        - status
+        - environment
+        - version
+        - requestId
+        - uptimeSeconds
+        - database
+        - config
+      properties:
+        status:
+          type: string
+          enum: [ok, degraded]
+          example: ok
+        environment:
+          type: string
+          example: production
+        version:
+          type: string
+          example: 1.0.0
+        requestId:
+          type: string
+          example: req-abc123
+        uptimeSeconds:
+          type: integer
+          example: 3600
+        database:
+          type: object
+          required:
+            - writable
+          properties:
+            writable:
+              type: boolean
+              example: true
+            path:
+              type: string
+              description: Included in non-production environments only.
+            target:
+              type: string
+              description: Included in non-production environments only.
+            error:
+              type: string
+              nullable: true
+              description: Included in non-production environments only.
+        config:
+          type: object
+          required:
+            - valid
+          properties:
+            valid:
+              type: boolean
+              example: true
+            missing:
+              type: array
+              items:
+                type: string
+              description: Included in non-production environments only.
+
     CreateTripRequest:
       type: object
       required:
@@ -116,15 +215,161 @@ components:
         error:
           type: string
           example: Trip not found
+        requestId:
+          type: string
+          description: Included in 404 catch-all and 500 error responses.
+          example: req-abc123
+
+    ValidationErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          example: Invalid checklist payload
+        message:
+          type: string
+          description: Detailed validation failure reason.
+          example: Each checklist item must have an "id" string field
+
+    LogoutResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
 
 security:
   - SessionAuth: []
 
+tags:
+  - name: Health
+    description: System health and readiness
+  - name: Auth
+    description: Google OAuth authentication flow
+  - name: Trips
+    description: Trip and checklist CRUD operations
+
 paths:
+  /health:
+    get:
+      tags: [Health]
+      summary: Health check
+      description: |
+        Returns system health status including database writability and configuration
+        validity. In production, internal paths and error details are omitted.
+        Returns 200 when healthy, 503 when degraded.
+      security: []
+      responses:
+        '200':
+          description: System is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+        '503':
+          description: System is degraded (database not writable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /auth/google:
+    get:
+      tags: [Auth]
+      summary: Initiate Google OAuth login
+      description: |
+        Redirects the browser to the Google OAuth consent screen.
+        Not available when `NODE_ENV=test`.
+      security: []
+      responses:
+        '302':
+          description: Redirect to Google OAuth consent screen
+
+  /auth/google/callback:
+    get:
+      tags: [Auth]
+      summary: Google OAuth callback
+      description: |
+        Handles the OAuth callback from Google. On success, establishes a session
+        and redirects to `FRONTEND_URL`. On failure, redirects to `/auth/login-error`.
+        Not available when `NODE_ENV=test`.
+      security: []
+      parameters:
+        - name: code
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Authorization code from Google
+      responses:
+        '302':
+          description: Redirect to frontend (success) or login-error (failure)
+
+  /auth/login-error:
+    get:
+      tags: [Auth]
+      summary: OAuth login failure redirect
+      description: |
+        Redirects to `FRONTEND_URL?authError=google_login_failed`.
+        Not available when `NODE_ENV=test`.
+      security: []
+      responses:
+        '302':
+          description: Redirect to frontend with authError query parameter
+
+  /auth/logout:
+    get:
+      tags: [Auth]
+      summary: Log out the current user
+      description: |
+        Destroys the server session, clears the `connect.sid` cookie,
+        and returns a success response.
+      responses:
+        '200':
+          description: Logout successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogoutResponse'
+        '500':
+          description: Internal server error during session destruction
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/user:
+    get:
+      tags: [Auth]
+      summary: Get the current authenticated user
+      description: |
+        Returns the user profile for the current session. Returns 401
+        if no valid session exists.
+      responses:
+        '200':
+          description: Authenticated user profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /api/trips:
     get:
+      tags: [Trips]
       summary: List trips for the authenticated user
-      description: Returns only the trips owned by the logged-in user.
+      description: Returns only the trips owned by the logged-in user, ordered by creation date (newest first).
       responses:
         '200':
           description: Array of trips
@@ -140,11 +385,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/saveTrip:
     post:
+      tags: [Trips]
       summary: Create a new trip
-      description: Creates a trip owned by the authenticated user.
+      description: |
+        Creates a trip owned by the authenticated user. The `name` and
+        `destinationType` fields are trimmed; blank values after trimming are
+        rejected. If a `checklist` array is provided, each item is validated
+        for required fields (`id`, `name`, `category`, `packed`).
       requestBody:
         required: true
         content:
@@ -159,13 +415,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/Trip'
         '400':
-          description: Validation error
+          description: |
+            Validation error. Returns `ErrorResponse` for missing/invalid fields,
+            or `ValidationErrorResponse` for invalid checklist items.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ErrorResponse'
+                  - $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        '401':
-          description: Unauthorized
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -173,6 +439,7 @@ paths:
 
   /api/trips/{tripId}:
     get:
+      tags: [Trips]
       summary: Get one trip
       description: Returns the trip if it exists and belongs to the authenticated user.
       parameters:
@@ -200,10 +467,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
     put:
+      tags: [Trips]
       summary: Update a trip
-      description: Partially updates a trip if it belongs to the authenticated user.
+      description: |
+        Partially updates a trip if it belongs to the authenticated user.
+        Only provided fields are updated. The `name` and `destinationType`
+        fields are trimmed; blank values after trimming are rejected.
+        If a `checklist` array is provided, each item is validated.
       parameters:
         - name: tripId
           in: path
@@ -224,11 +502,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/Trip'
         '400':
-          description: Validation error
+          description: |
+            Validation error. Returns `ErrorResponse` for blank or invalid fields,
+            or `ValidationErrorResponse` for invalid checklist items.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                oneOf:
+                  - $ref: '#/components/schemas/ErrorResponse'
+                  - $ref: '#/components/schemas/ValidationErrorResponse'
         '401':
           description: Unauthorized
           content:
@@ -241,8 +523,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
     delete:
+      tags: [Trips]
       summary: Delete a trip
       description: Deletes a trip and its checklist items if it belongs to the authenticated user.
       parameters:
@@ -262,6 +551,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Trip not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary
Expands API interface documentation to cover the full server surface area and to satisfy every line of the Week 14 Deliverable D rubric.

### `docs/api/openapi.yaml` — expanded from 267 to ~570 lines
- Added 6 previously-undocumented routes: `GET /health`, `GET /auth/google`, `GET /auth/google/callback`, `GET /auth/login-error`, `GET /auth/logout`, `GET /auth/user`
- Added 4 new schemas: `User`, `HealthResponse`, `ValidationErrorResponse`, `LogoutResponse`
- Added `500` responses to every applicable route
- Added `oneOf` for `400` responses on POST/PUT to distinguish field-level errors from checklist-item validation errors
- Added `requestId` to `ErrorResponse`
- Added production server URL and grouped routes with `tags` (Health, Auth, Trips)
- Bumped spec version to 1.1.0

### `docs/api/README.md` — new file
- Endpoint summary table (all 11 routes)
- Authentication flow walkthrough (5-step sequence from browser → Google → session)
- Request lifecycle diagram (middleware → auth → handler → storage → DB)
- External integrations section (Google OAuth, SQLite/better-sqlite3, Winston)
- Internal services reference (storage, auth middleware, logger, checklist generator)
- Environment variable reference
- 3 curl examples

## Rubric coverage

| Requirement | Covered by |
|---|---|
| Routes/endpoints | openapi.yaml + README summary table |
| Request inputs | Schemas, path params, query params, request bodies |
| Response shapes | 7 schemas covering every response variant |
| Auth requirements | `SessionAuth` scheme, per-route security, README auth flow |
| Common failure responses | 400, 401, 404, 500 on every applicable route |
| Major internal services | README "Internal services" section |
| Data flow between modules | README "Request lifecycle" diagram |
| External integrations | README "External integrations" table |
| Examples | 3 curl examples in README |

## Validation
- `npx swagger-cli validate docs/api/openapi.yaml` passes
- Swagger UI mount at `/docs` (unchanged) will auto-serve the expanded spec

## Test plan
- [ ] Run `npm run dev:full` and confirm `/docs` renders the expanded spec without errors
- [ ] Spot-check a curl example against a local dev server
- [ ] Verify README renders cleanly on GitHub

## Notes for reviewers
- No server code changes — documentation only
- The `oneOf` pattern on POST/PUT 400 responses captures the existing server behavior where checklist validation returns `{ error, message }` but field validation returns `{ error }` only. If we want a single unified error shape, that's a follow-up code change (not in scope for this PR)
- Branch `week14/api-documentation` is based on `main` (not on Heather's `week14/user-and-admin-guides`) — no merge conflicts expected