### PR TITLE
WIP: Add input length limits on trip fields (#81)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -178,9 +178,11 @@ components:
       properties:
         name:
           type: string
+          maxLength: 100
           example: My Beach Trip
         destinationType:
           type: string
+          maxLength: 50
           example: beach
         duration:
           type: integer
@@ -196,9 +198,11 @@ components:
       properties:
         name:
           type: string
+          maxLength: 100
           example: Updated Beach Trip
         destinationType:
           type: string
+          maxLength: 50
           example: beach
         duration:
           type: integer

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <p id="editing-context" style="color: #6b7280; margin-bottom: 1rem;" hidden></p>
       <form id="trip-form">
         <label for="trip-name">Trip Name <span class="required-marker" aria-hidden="true">*</span></label>
-        <input type="text" id="trip-name" name="name" placeholder="e.g. Spring Break 2026" required />
+        <input type="text" id="trip-name" name="name" placeholder="e.g. Spring Break 2026" maxlength="100" required />
 
         <label for="destination-type">Destination Type <span class="required-marker" aria-hidden="true">*</span></label>
         <select id="destination-type" name="destinationType" required>

--- a/server.js
+++ b/server.js
@@ -441,6 +441,22 @@ app.post('/api/saveTrip', requireAuth, async (req, res) => {
       return res.status(400).json({ error: `Missing required fields: ${missingFields.join(', ')}` });
     }
 
+    if (trimmedName.length > 100) {
+      await log(requestId, 'CREATE_TRIP', 'VALIDATION_ERROR', {
+        reason: 'Trip name exceeds maximum length',
+        received: { nameLength: trimmedName.length, max: 100 },
+      });
+      return res.status(400).json({ error: 'Trip name must be 100 characters or fewer' });
+    }
+
+    if (trimmedType.length > 50) {
+      await log(requestId, 'CREATE_TRIP', 'VALIDATION_ERROR', {
+        reason: 'Destination type exceeds maximum length',
+        received: { destinationTypeLength: trimmedType.length, max: 50 },
+      });
+      return res.status(400).json({ error: 'Destination type must be 50 characters or fewer' });
+    }
+
     if (!Number.isInteger(duration) || duration < 1) {
       await log(requestId, 'CREATE_TRIP', 'VALIDATION_ERROR', {
         reason: 'Invalid duration value',
@@ -531,8 +547,14 @@ app.put('/api/trips/:tripId', requireAuth, async (req, res) => {
     if (name !== undefined && !name.trim()) {
       return res.status(400).json({ error: 'name must not be blank' });
     }
+    if (name !== undefined && name.trim().length > 100) {
+      return res.status(400).json({ error: 'Trip name must be 100 characters or fewer' });
+    }
     if (destinationType !== undefined && !destinationType.trim()) {
       return res.status(400).json({ error: 'destinationType must not be blank' });
+    }
+    if (destinationType !== undefined && destinationType.trim().length > 50) {
+      return res.status(400).json({ error: 'Destination type must be 50 characters or fewer' });
     }
 
     if (checklist && Array.isArray(checklist)) {

--- a/server.js
+++ b/server.js
@@ -37,6 +37,8 @@ const isDirectRun = process.argv[1] && path.resolve(process.argv[1]) === __filen
 
 const MAX_REQUEST_ID_LENGTH = 128;
 const REQUEST_ID_HEADER_VALUE_PATTERN = /^[A-Za-z0-9._-]+$/;
+const MAX_TRIP_NAME_LENGTH = 100;
+const MAX_DESTINATION_TYPE_LENGTH = 50;
 
 function isMissingConfigValue(key) {
   const value = process.env[key];
@@ -441,20 +443,20 @@ app.post('/api/saveTrip', requireAuth, async (req, res) => {
       return res.status(400).json({ error: `Missing required fields: ${missingFields.join(', ')}` });
     }
 
-    if (trimmedName.length > 100) {
+    if (trimmedName.length > MAX_TRIP_NAME_LENGTH) {
       await log(requestId, 'CREATE_TRIP', 'VALIDATION_ERROR', {
         reason: 'Trip name exceeds maximum length',
-        received: { nameLength: trimmedName.length, max: 100 },
+        received: { nameLength: trimmedName.length, max: MAX_TRIP_NAME_LENGTH },
       });
-      return res.status(400).json({ error: 'Trip name must be 100 characters or fewer' });
+      return res.status(400).json({ error: `name must be ${MAX_TRIP_NAME_LENGTH} characters or fewer` });
     }
 
-    if (trimmedType.length > 50) {
+    if (trimmedType.length > MAX_DESTINATION_TYPE_LENGTH) {
       await log(requestId, 'CREATE_TRIP', 'VALIDATION_ERROR', {
         reason: 'Destination type exceeds maximum length',
-        received: { destinationTypeLength: trimmedType.length, max: 50 },
+        received: { destinationTypeLength: trimmedType.length, max: MAX_DESTINATION_TYPE_LENGTH },
       });
-      return res.status(400).json({ error: 'Destination type must be 50 characters or fewer' });
+      return res.status(400).json({ error: `destinationType must be ${MAX_DESTINATION_TYPE_LENGTH} characters or fewer` });
     }
 
     if (!Number.isInteger(duration) || duration < 1) {
@@ -547,14 +549,14 @@ app.put('/api/trips/:tripId', requireAuth, async (req, res) => {
     if (name !== undefined && !name.trim()) {
       return res.status(400).json({ error: 'name must not be blank' });
     }
-    if (name !== undefined && name.trim().length > 100) {
-      return res.status(400).json({ error: 'Trip name must be 100 characters or fewer' });
+    if (name !== undefined && name.trim().length > MAX_TRIP_NAME_LENGTH) {
+      return res.status(400).json({ error: `name must be ${MAX_TRIP_NAME_LENGTH} characters or fewer` });
     }
     if (destinationType !== undefined && !destinationType.trim()) {
       return res.status(400).json({ error: 'destinationType must not be blank' });
     }
-    if (destinationType !== undefined && destinationType.trim().length > 50) {
-      return res.status(400).json({ error: 'Destination type must be 50 characters or fewer' });
+    if (destinationType !== undefined && destinationType.trim().length > MAX_DESTINATION_TYPE_LENGTH) {
+      return res.status(400).json({ error: `destinationType must be ${MAX_DESTINATION_TYPE_LENGTH} characters or fewer` });
     }
 
     if (checklist && Array.isArray(checklist)) {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -277,7 +277,7 @@ describe('POST /api/saveTrip', () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('Trip name must be 100 characters or fewer');
+    expect(res.body.error).toBe('name must be 100 characters or fewer');
   });
 
   it('returns 400 when destinationType exceeds 50 characters', async () => {
@@ -289,7 +289,7 @@ describe('POST /api/saveTrip', () => {
     });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('Destination type must be 50 characters or fewer');
+    expect(res.body.error).toBe('destinationType must be 50 characters or fewer');
   });
 });
 
@@ -502,7 +502,7 @@ describe('PUT /api/trips/:tripId', () => {
       .send({ name: 'a'.repeat(101) });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('Trip name must be 100 characters or fewer');
+    expect(res.body.error).toBe('name must be 100 characters or fewer');
   });
 
   it('returns 400 when destinationType update exceeds 50 characters', async () => {
@@ -517,7 +517,7 @@ describe('PUT /api/trips/:tripId', () => {
       .send({ destinationType: 'b'.repeat(51) });
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('Destination type must be 50 characters or fewer');
+    expect(res.body.error).toBe('destinationType must be 50 characters or fewer');
   });
 });
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -267,6 +267,30 @@ describe('POST /api/saveTrip', () => {
     expect(res.body.error).toBe('Invalid checklist payload');
     expect(res.body.message).toMatch(/category.*string/);
   });
+
+  it('returns 400 when name exceeds 100 characters', async () => {
+    const res = await authRequest('post', '/api/saveTrip').send({
+      name: 'a'.repeat(101),
+      destinationType: 'beach',
+      duration: 3,
+      checklist: [],
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Trip name must be 100 characters or fewer');
+  });
+
+  it('returns 400 when destinationType exceeds 50 characters', async () => {
+    const res = await authRequest('post', '/api/saveTrip').send({
+      name: 'Valid Name',
+      destinationType: 'b'.repeat(51),
+      duration: 3,
+      checklist: [],
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Destination type must be 50 characters or fewer');
+  });
 });
 
 describe('GET /api/trips', () => {
@@ -464,6 +488,36 @@ describe('PUT /api/trips/:tripId', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/destinationType must not be blank/);
+  });
+
+  it('returns 400 when name update exceeds 100 characters', async () => {
+    const create = await authRequest('post', '/api/saveTrip', userAId).send({
+      name: 'Length Test',
+      destinationType: 'city',
+      duration: 3,
+      checklist: [],
+    });
+
+    const res = await authRequest('put', `/api/trips/${create.body.id}`, userAId)
+      .send({ name: 'a'.repeat(101) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Trip name must be 100 characters or fewer');
+  });
+
+  it('returns 400 when destinationType update exceeds 50 characters', async () => {
+    const create = await authRequest('post', '/api/saveTrip', userAId).send({
+      name: 'Length Test',
+      destinationType: 'city',
+      duration: 3,
+      checklist: [],
+    });
+
+    const res = await authRequest('put', `/api/trips/${create.body.id}`, userAId)
+      .send({ destinationType: 'b'.repeat(51) });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Destination type must be 50 characters or fewer');
   });
 });
 


### PR DESCRIPTION
Closes [#81](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-4/issues/81).

## Changes

### Frontend
- `index.html` — `maxlength="100"` added to `#trip-name`. (`#destination-type` is a `<select>` with fixed enum values, so no client-side limit needed; server-side check below is defense-in-depth.)

### Server
- `server.js` POST `/api/saveTrip` — adds two length checks after the existing missing-fields check:
  - Name length > 100 → 400 with `"Trip name must be 100 characters or fewer"`
  - Destination type length > 50 → 400 with `"Destination type must be 50 characters or fewer"`
  - Both log a structured `VALIDATION_ERROR` event matching the existing pattern
- `server.js` PUT `/api/trips/:tripId` — adds the same two length checks alongside the existing blank-checks (no log; matches existing PUT pattern of plain-400 for blank).

### Tests
Four new Vitest cases in `tests/server.test.js`:
- POST returns 400 when name exceeds 100 chars
- POST returns 400 when destinationType exceeds 50 chars
- PUT returns 400 when name update exceeds 100 chars
- PUT returns 400 when destinationType update exceeds 50 chars

## Verification

`npm run test:unit` — 47 tests pass (was 43 baseline; +4 new tests).

## Sprint plan reference

Resolves item 1 of the Week 15 sprint plan (PR #148, "Close XSS Audit and Trip-Field Length Limits"). Bundled with [#82](https://github.com/Georgia-Southwestern-State-Univeristy/term-project-group-4/issues/82) (PR #154 — XSS audit).