### PR TITLE
week16/fix-update-trip-state

### DIFF
--- a/src/tripForm.js
+++ b/src/tripForm.js
@@ -293,9 +293,7 @@ export function initTripForm({ onTripSaved } = {}) {
       }
 
       if (onTripSaved) await onTripSaved();
-
-      // Keep disabled after new-trip reset; re-enable only for loaded/edit trips.
-      saveTripBtn.disabled = !savedTripId;
+      
     } catch (err) {
       showToast(`Failed to save trip: ${err.message}`, 'error');
       console.error('Failed to save trip:', err);

--- a/src/tripForm.js
+++ b/src/tripForm.js
@@ -63,14 +63,15 @@ export function initTripForm({ onTripSaved } = {}) {
   }
 
   /**
-   * Capture the current form state for change detection
+   * Capture only the Create a Trip fields for edit-mode change detection.
+   * Checklist item packed/unpacked state is auto-saved separately and should
+   * not enable the Update Trip button.
    */
   function captureFormState() {
     return {
       name: form.elements['name'].value || '',
       destinationType: form.elements['destinationType'].value || '',
       duration: form.elements['duration'].value || '',
-      checklist: currentChecklist ? JSON.stringify(currentChecklist) : '',
     };
   }
 
@@ -85,7 +86,9 @@ export function initTripForm({ onTripSaved } = {}) {
   }
 
   /**
-   * Check if form has changed from the saved state
+   * Check if the Create a Trip fields have changed from the saved state.
+   * Checklist item changes are intentionally excluded because they auto-save
+   * independently and should not affect the Update Trip button.
    */
   function checkForChanges() {
     if (!isEditingExistingTrip || !originalFormState) {
@@ -96,8 +99,7 @@ export function initTripForm({ onTripSaved } = {}) {
     const changed =
       currentState.name !== originalFormState.name ||
       currentState.destinationType !== originalFormState.destinationType ||
-      currentState.duration !== originalFormState.duration ||
-      currentState.checklist !== originalFormState.checklist;
+      currentState.duration !== originalFormState.duration;
 
     hasChanges = changed;
     updateButtonState();
@@ -193,12 +195,12 @@ export function initTripForm({ onTripSaved } = {}) {
     }
   }, 600);
 
-  // When a checkbox changes and the trip has been saved, sync to server
+  // When a checkbox changes and the trip has been saved, sync checklist state
+  // to the server. This should not mark the trip details form as changed.
   setOnChecklistChange((checklist) => {
     if (savedTripId) {
       autoSaveChecklist(checklist);
     }
-    checkForChanges();
   });
 
   /**
@@ -244,8 +246,14 @@ export function initTripForm({ onTripSaved } = {}) {
     }
   });
 
-  // Add change detection to form inputs
-  form.addEventListener('input', checkForChanges);
+  // Only trip-detail fields should enable the Update Trip button in edit mode.
+  // Checklist checkbox changes are handled by auto-save and should not mark
+  // the trip details as dirty.
+  [nameInput, destinationInput, durationInput].forEach((field) => {
+    if (!field) return;
+    field.addEventListener('input', checkForChanges);
+    field.addEventListener('change', checkForChanges);
+  });
 
   updateGenerateButtonState();
   setSaveButtonForNewTrip();


### PR DESCRIPTION
## Summary

Closes #150.

Updates edit-mode change detection so the **Update Trip** button is only tied to changes in the Create a Trip fields:

- Trip Name
- Destination Type
- Duration

Checklist checkbox changes still auto-save, but they no longer mark the trip details as changed or enable the **Update Trip** button.

## Why

When a saved trip was loaded, checking or unchecking checklist items caused the **Update Trip** button to become enabled. This was confusing because checklist item state already auto-saves separately and does not require the user to manually update the trip.

The intended behavior is:

- checklist item changes → auto-save only
- trip detail changes → enable **Update Trip**

## Changes

- Removed checklist contents from edit-mode dirty-state tracking.
- Updated form state capture to compare only:
  - `name`
  - `destinationType`
  - `duration`
- Removed `checkForChanges()` from the checklist checkbox change callback.
- Kept checklist auto-save behavior unchanged.
- Tied edit-mode change detection directly to the Create a Trip fields.
- After a successful trip update, the baseline form state resets and **Update Trip** becomes disabled again.

## How to Verify

1. Log in to the app.
2. Create a trip and generate a checklist.
3. Save the trip.
4. Load the saved trip.
5. Confirm the button shows **Update Trip** and is disabled.
6. Check or uncheck one or more checklist items.
7. Confirm **Update Trip** remains disabled.
8. Refresh the page and reload the trip.
9. Confirm the checklist checked/unchecked state persisted.
10. Edit the Trip Name, Destination Type, or Duration.
11. Confirm **Update Trip** becomes enabled.
12. Click **Update Trip**.
13. Confirm the update succeeds and **Update Trip** becomes disabled again.

## Expected Behavior

- Checklist checkbox changes do not enable **Update Trip**.
- Checklist checkbox changes still auto-save and persist.
- Editing Trip Name enables **Update Trip**.
- Editing Destination Type enables **Update Trip**.
- Editing Duration enables **Update Trip**.
- After a successful update, **Update Trip** is disabled until another trip-detail field changes.

## Test Plan

- [x] Manually verified checklist checkbox changes do not enable **Update Trip**
- [x] Manually verified checklist checkbox changes still persist after refresh/reload
- [x] Manually verified editing Trip Name enables **Update Trip**
- [x] Manually verified editing Destination Type enables **Update Trip**
- [x] Manually verified editing Duration enables **Update Trip**
- [x] Manually verified **Update Trip** disables again after successful save
- [x] Ran relevant tests locally: `npm run test`

## Notes for Reviewers

Please focus review on edit-mode dirty-state behavior and confirm that checklist auto-save remains separate from trip-detail updates.